### PR TITLE
Disable distribution for VoidableCallback conditional type. Resolves #42

### DIFF
--- a/src/use-event-callback.ts
+++ b/src/use-event-callback.ts
@@ -3,7 +3,7 @@ import { Observable, BehaviorSubject, Subject, noop } from 'rxjs'
 
 import { RestrictArray, VoidAsNull, Not } from './type'
 
-type VoidableCallback<EventValue> = EventValue extends void ? () => void : (val: EventValue) => void
+type VoidableCallback<EventValue> = [EventValue] extends [void] ? () => void : (val: EventValue) => void
 
 export type EventCallbackState<EventValue, State, Inputs = void> = [
   VoidableCallback<EventValue>,


### PR DESCRIPTION
I asked a question on stackoverflow ([here](https://stackoverflow.com/questions/55542332/typescript-conditional-type-with-discriminated-union)), and this PR is based on the answer.