### PR TITLE
Reduce object creation by useConstant

### DIFF
--- a/package.json
+++ b/package.json
@@ -56,7 +56,8 @@
     "webpack-dev-server": "^3.9.0"
   },
   "dependencies": {
-    "tslib": "^1.10.0"
+    "tslib": "^1.10.0",
+    "use-constant": "^1.0.0"
   },
   "lint-staged": {
     "*.js": [

--- a/src/use-observable.ts
+++ b/src/use-observable.ts
@@ -1,5 +1,6 @@
 import { Observable, BehaviorSubject } from 'rxjs'
-import { useState, useEffect, useMemo } from 'react'
+import { useState, useEffect } from 'react'
+import useConstant from 'use-constant'
 
 import { RestrictArray } from './type'
 
@@ -22,45 +23,35 @@ export function useObservable<State, Inputs extends ReadonlyArray<any>>(
 ): State | null {
   const [state, setState] = useState(typeof initialState !== 'undefined' ? initialState : null)
 
-  const { state$, inputs$ } = useMemo(() => {
-    const stateSubject$ = new BehaviorSubject<State | undefined>(initialState)
-    const inputSubject$ = new BehaviorSubject<RestrictArray<Inputs> | undefined>(inputs)
-
-    return {
-      state$: stateSubject$,
-      inputs$: inputSubject$,
-    }
-  }, [])
+  const state$ = useConstant(() => new BehaviorSubject<State | undefined>(initialState))
+  const inputs$ = useConstant(() => new BehaviorSubject<RestrictArray<Inputs> | undefined>(inputs))
 
   useEffect(() => {
     inputs$.next(inputs)
   }, inputs || [])
 
-  useEffect(
-    () => {
-      let output$: BehaviorSubject<State>
-      if (inputs) {
-        output$ = (inputFactory as (
-          inputs$: Observable<RestrictArray<Inputs> | undefined>,
-          state$: Observable<State | undefined>,
-        ) => Observable<State>)(inputs$, state$) as BehaviorSubject<State>
-      } else {
-        output$ = (inputFactory as (state$: Observable<State | undefined>) => Observable<State>)(
-          state$,
-        ) as BehaviorSubject<State>
-      }
-      const subscription = output$.subscribe((value) => {
-        state$.next(value)
-        setState(value)
-      })
-      return () => {
-        subscription.unsubscribe()
-        inputs$.complete()
-        state$.complete()
-      }
-    },
-    [], // immutable forever
-  )
+  useEffect(() => {
+    let output$: BehaviorSubject<State>
+    if (inputs) {
+      output$ = (inputFactory as (
+        inputs$: Observable<RestrictArray<Inputs> | undefined>,
+        state$: Observable<State | undefined>,
+      ) => Observable<State>)(inputs$, state$) as BehaviorSubject<State>
+    } else {
+      output$ = (inputFactory as (state$: Observable<State | undefined>) => Observable<State>)(
+        state$,
+      ) as BehaviorSubject<State>
+    }
+    const subscription = output$.subscribe((value) => {
+      state$.next(value)
+      setState(value)
+    })
+    return () => {
+      subscription.unsubscribe()
+      inputs$.complete()
+      state$.complete()
+    }
+  }, []) // immutable forever
 
   return state
 }

--- a/yarn.lock
+++ b/yarn.lock
@@ -7587,6 +7587,11 @@ url@^0.11.0:
     punycode "1.3.2"
     querystring "0.2.0"
 
+use-constant@^1.0.0:
+  version "1.0.0"
+  resolved "https://registry.yarnpkg.com/use-constant/-/use-constant-1.0.0.tgz#cfab998e6fc19ddc62b056875709f1420e339a10"
+  integrity sha512-HmVrMl3+1tEr64ace4UtP5WTdnLyrvYKwF54JVf7B7lSB76JSERDvvgWkaaxlOM3S0dSl1U3WH1l9PupNnzsvQ==
+
 use@^3.1.0:
   version "3.1.1"
   resolved "https://registry.yarnpkg.com/use/-/use-3.1.1.tgz#d50c8cac79a19fbc20f2911f56eb973f4e10070f"


### PR DESCRIPTION
Hello 🙌🏻

`use-constant` is better then `use-memo` and `use-state`, when created object is CONSTANT, because `use-constant` don't have cache invalidation and state change logic, just saves value in ref

fix #51 

https://github.com/Andarist/use-constant/issues/3
https://github.com/Andarist/use-constant/issues/4

