### PR TITLE
fix: Specify react and rxjs in peerDependencies

### DIFF
--- a/package.json
+++ b/package.json
@@ -55,6 +55,10 @@
     "webpack-cli": "^3.3.10",
     "webpack-dev-server": "^3.9.0"
   },
+  "peerDependencies": {
+    "react": "^16.13.1",
+    "rxjs": "^6.5.3"
+  },
   "dependencies": {
     "tslib": "^2.0.0",
     "use-constant": "^1.0.0"


### PR DESCRIPTION
Dependencies should be specified in either `dependencies` or `peerDependencies` section of `package.json` when accessed in production code via `import` statements or `require`s. It seems that although rxjs-hooks is importing `react` and `rxjs` in its production code, neither of them is specified.

Below is a part of the production bundle where `rxjs` and `react` is imported. (`dist/esm/use-event-callback.js`)

<img width="500" alt="image" src="https://user-images.githubusercontent.com/3102175/93583741-44789d80-f9df-11ea-9cd4-e94f0b82a4bc.png">

This makes the library to break in environments using strict dependency management systems such as [yarn v2](https://yarnpkg.com/).

This pull request fixes the issue by specifying `react` and `rxjs` in `peerDependencies` of package.json.